### PR TITLE
Remove usage of __dev{init,initdata,exit}

### DIFF
--- a/src/alx.h
+++ b/src/alx.h
@@ -206,7 +206,7 @@ extern int alx_alloc_rxring_buf(struct alx_adapter *adpt,
 extern void alx_init_intr(struct alx_adapter *adpt);
 extern void alx_disable_advanced_intr(struct alx_adapter *adpt);
 extern void alx_reinit(struct alx_adapter *adpt);
-extern void __devinit alx_set_ethtool_ops(struct net_device *dev);
+extern void alx_set_ethtool_ops(struct net_device *dev);
 extern char alx_drv_name[];
 extern char alx_drv_version[];
 

--- a/src/alx_ethtool.c
+++ b/src/alx_ethtool.c
@@ -1795,7 +1795,7 @@ static const struct ethtool_ops alx_ethtool_ops = {
 	.set_priv_flags	 = alx_set_priv_flags,
 };
 
-void __devinit alx_set_ethtool_ops(struct net_device *dev)
+void alx_set_ethtool_ops(struct net_device *dev)
 {
 	SET_ETHTOOL_OPS(dev, &alx_ethtool_ops);
 }

--- a/src/alx_hw.c
+++ b/src/alx_hw.c
@@ -1416,12 +1416,12 @@ void __alx_update_hw_stats(struct alx_hw *hw)
 	}
 }
 
-static const struct alx_platform_patch plats[] __devinitdata = {
+static const struct alx_platform_patch plats[] = {
 {0x1091, 0x00, 0x1969, 0x0091, 0x1001},
 {0},
 };
 
-void __devinit alx_patch_assign(struct alx_hw *hw)
+void alx_patch_assign(struct alx_hw *hw)
 {
 	int i = 0;
 
@@ -1440,7 +1440,7 @@ void __devinit alx_patch_assign(struct alx_hw *hw)
 	}
 }
 
-bool __devinit alx_get_phy_info(struct alx_hw *hw)
+bool alx_get_phy_info(struct alx_hw *hw)
 {
 	u16  devs1, devs2;
 

--- a/src/alx_hw.h
+++ b/src/alx_hw.h
@@ -655,7 +655,7 @@ struct alx_platform_patch {
 #define ALX_PF_ANY_REV		0x10000
 
 
-void __devinit alx_patch_assign(struct alx_hw *hw);
-bool __devinit alx_get_phy_info(struct alx_hw *hw);
+void alx_patch_assign(struct alx_hw *hw);
+bool alx_get_phy_info(struct alx_hw *hw);
 
 #endif

--- a/src/alx_main.c
+++ b/src/alx_main.c
@@ -994,7 +994,7 @@ static void alx_free_irq(struct alx_adapter *adpt)
 }
 
 
-static int __devinit alx_identify_hw(struct alx_adapter *adpt)
+static int alx_identify_hw(struct alx_adapter *adpt)
 {
 	struct pci_dev *pdev = adpt->pdev;
 	struct alx_hw *hw = &adpt->hw;
@@ -1039,7 +1039,7 @@ static int __devinit alx_identify_hw(struct alx_adapter *adpt)
 }
 
 
-static const u8 def_rss_key[40] __devinitdata = {
+static const u8 def_rss_key[40] = {
 	0xE2, 0x91, 0xD7, 0x3D, 0x18, 0x05, 0xEC, 0x6C,
 	0x2A, 0x94, 0xB3, 0x0D, 0xA5, 0x4F, 0x2B, 0xEC,
 	0xEA, 0x49, 0xAF, 0x7C, 0xE2, 0x14, 0xAD, 0x3D,
@@ -1066,7 +1066,7 @@ void alx_init_def_rss_idt(struct alx_adapter *adpt)
  *    initialize general software structure (struct alx_adapter).
  *    fields are inited based on PCI device information.
  */
-static int __devinit alx_init_sw(struct alx_adapter *adpt)
+static int alx_init_sw(struct alx_adapter *adpt)
 {
 	struct pci_dev	*pdev = adpt->pdev;
 	struct alx_hw *hw = &adpt->hw;
@@ -2466,7 +2466,7 @@ static const struct net_device_ops alx_netdev_ops = {
 };
 
 /* alx_probe - Device Initialization Routine */
-static int __devinit
+static int
 alx_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 {
 	struct net_device *netdev;
@@ -2677,7 +2677,7 @@ err_dma_mask:
 }
 
 /* alx_remove - Device Removal Routine */
-static void __devexit alx_remove(struct pci_dev *pdev)
+static void alx_remove(struct pci_dev *pdev)
 {
 	struct alx_adapter *adpt = pci_get_drvdata(pdev);
 	struct alx_hw *hw = &adpt->hw;
@@ -2797,7 +2797,7 @@ static struct pci_driver alx_driver = {
 	.name        = alx_drv_name,
 	.id_table    = alx_pci_tbl,
 	.probe       = alx_probe,
-	.remove      = __devexit_p(alx_remove),
+	.remove      = alx_remove,
 	.shutdown    = alx_shutdown,
 	.err_handler = &alx_err_handler,
 	.driver.pm   = ALX_PM_OPS,


### PR DESCRIPTION
CONFIG_HOTPLUG is no longer an optional setting.

Signed-off-by: Felix Kaechele felix@fetzig.org

Fails to build on >= 3.8 when __dev\* macros are used.
