### PR TITLE
alx: support Killer E2200

### DIFF
--- a/src/alx_ethtool.c
+++ b/src/alx_ethtool.c
@@ -731,6 +731,7 @@ static int alx_diag_register(struct alx_adapter *adpt, u64 *data)
 
 	switch (ALX_DID(hw)) {
 	case ALX_DEV_ID_AR8161:
+	case ALX_DEV_ID_E2200:
 	case ALX_DEV_ID_AR8162:
 	case ALX_DEV_ID_AR8171:
 	case ALX_DEV_ID_AR8172:

--- a/src/alx_main.c
+++ b/src/alx_main.c
@@ -57,6 +57,7 @@ static const char alx_drv_desc[] =
 	PCI_DEVICE(ALX_VENDOR_ID, device_id)}
 static DEFINE_PCI_DEVICE_TABLE(alx_pci_tbl) = {
 	ALX_ETHER_DEVICE(ALX_DEV_ID_AR8161),
+	ALX_ETHER_DEVICE(ALX_DEV_ID_E2200),
 	ALX_ETHER_DEVICE(ALX_DEV_ID_AR8162),
 	ALX_ETHER_DEVICE(ALX_DEV_ID_AR8171),
 	ALX_ETHER_DEVICE(ALX_DEV_ID_AR8172),
@@ -1010,6 +1011,7 @@ static int alx_identify_hw(struct alx_adapter *adpt)
 
 	switch (ALX_DID(hw)) {
 	case ALX_DEV_ID_AR8161:
+	case ALX_DEV_ID_E2200:
 	case ALX_DEV_ID_AR8162:
 	case ALX_DEV_ID_AR8171:
 	case ALX_DEV_ID_AR8172:

--- a/src/alx_reg.h
+++ b/src/alx_reg.h
@@ -25,6 +25,7 @@
 
 /* pci dev-ids */
 #define ALX_DEV_ID_AR8161               0x1091
+#define ALX_DEV_ID_E2200                0xe091
 #define ALX_DEV_ID_AR8162               0x1090
 #define ALX_DEV_ID_AR8171               0x10A1
 #define ALX_DEV_ID_AR8172               0x10A0


### PR DESCRIPTION
add pci device id for Killer E2200, which is a rebrand of the AR8161

Signed-off-by: Sauyon git@sauyon.com
